### PR TITLE
Fixed casing issue on paths

### DIFF
--- a/modules/policyDefinition/locals.tf
+++ b/modules/policyDefinition/locals.tf
@@ -5,10 +5,10 @@ locals {
   # import the custom policy object from a library or specified file path
   policy_object = jsondecode(coalesce(try(
     file(var.file_path),
-    file("${path.cwd}/custompolicies/definitions/${title(lower(var.policy_category))}/${var.policy_def_name}.json"),
-    file("${path.root}/custompolicies/definitions/${title(lower(var.policy_category))}/${var.policy_def_name}.json"),
-    file("${path.root}/custompolicies/definitions/${title(lower(var.policy_category))}/${var.policy_def_name}.json"),
-    file("${path.module}/custompolicies/definitions/${title(lower(var.policy_category))}/${var.policy_def_name}.json")
+    file("${path.cwd}/custompolicies/definitions/${lower(var.policy_category)}/${var.policy_def_name}.json"),
+    file("${path.root}/custompolicies/definitions/${lower(var.policy_category)}/${var.policy_def_name}.json"),
+    file("${path.root}/custompolicies/definitions/${lower(var.policy_category)}/${var.policy_def_name}.json"),
+    file("${path.module}/custompolicies/definitions/${lower(var.policy_category)}/${var.policy_def_name}.json")
   )))
 
   # fallbacks


### PR DESCRIPTION
## Describe your changes
Removed title() function calls from paths.  All folders are lower-case and this was causing File not Found errors.

## Issue number

#18 

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine

Thanks for your cooperation!

