### PR TITLE
Correct spelling across repo

### DIFF
--- a/modules/policyDefAssignment/managementGroup/locals.tf
+++ b/modules/policyDefAssignment/managementGroup/locals.tf
@@ -23,7 +23,7 @@ locals {
   # determine if a managed identity should be created with this assignment
   identity_type = length(try(coalescelist(var.role_definition_ids, lookup(jsondecode(var.definition.policy_rule).then.details, "roleDefinitionIds", [])), [])) > 0 ? var.identity_ids != null ? { type = "UserAssigned" } : { type = "SystemAssigned" } : {}
 
-  # try to use policy definition roles if explicit roles are ommitted
+  # try to use policy definition roles if explicit roles are omitted
   role_definition_ids = var.skip_role_assignment == false ? try(coalescelist(var.role_definition_ids, lookup(jsondecode(var.definition.policy_rule).then.details, "roleDefinitionIds", [])), []) : []
 
   # policy assignment scope will be used if omitted

--- a/modules/policyDefAssignment/managementGroup/outputs.tf
+++ b/modules/policyDefAssignment/managementGroup/outputs.tf
@@ -18,6 +18,6 @@ output "remediation_id" {
 }
 
 output "role_definition_ids" {
-  description = "The List of Role Defenition Ids assignable to the managed identity"
+  description = "The List of Role Definition Ids assignable to the managed identity"
   value       = local.role_definition_ids
 }

--- a/modules/policyDefAssignment/resource/locals.tf
+++ b/modules/policyDefAssignment/resource/locals.tf
@@ -23,7 +23,7 @@ locals {
   # determine if a managed identity should be created with this assignment
   identity_type = length(try(coalescelist(var.role_definition_ids, lookup(jsondecode(var.definition.policy_rule).then.details, "roleDefinitionIds", [])), [])) > 0 ? var.identity_ids != null ? { type = "UserAssigned" } : { type = "SystemAssigned" } : {}
 
-  # try to use policy definition roles if explicit roles are ommitted
+  # try to use policy definition roles if explicit roles are omitted
   role_definition_ids = var.skip_role_assignment == false ? try(coalescelist(var.role_definition_ids, lookup(jsondecode(var.definition.policy_rule).then.details, "roleDefinitionIds", [])), []) : []
 
   # policy assignment scope will be used if omitted

--- a/modules/policyDefAssignment/resource/outputs.tf
+++ b/modules/policyDefAssignment/resource/outputs.tf
@@ -18,6 +18,6 @@ output "remediation_id" {
 }
 
 output "role_definition_ids" {
-  description = "The List of Role Defenition Ids assignable to the managed identity"
+  description = "The List of Role Definition Ids assignable to the managed identity"
   value       = local.role_definition_ids
 }

--- a/modules/policyDefAssignment/resourceGroup/locals.tf
+++ b/modules/policyDefAssignment/resourceGroup/locals.tf
@@ -23,7 +23,7 @@ locals {
   # determine if a managed identity should be created with this assignment
   identity_type = length(try(coalescelist(var.role_definition_ids, lookup(jsondecode(var.definition.policy_rule).then.details, "roleDefinitionIds", [])), [])) > 0 ? var.identity_ids != null ? { type = "UserAssigned" } : { type = "SystemAssigned" } : {}
 
-  # try to use policy definition roles if explicit roles are ommitted
+  # try to use policy definition roles if explicit roles are omitted
   role_definition_ids = var.skip_role_assignment == false ? try(coalescelist(var.role_definition_ids, lookup(jsondecode(var.definition.policy_rule).then.details, "roleDefinitionIds", [])), []) : []
 
   # policy assignment scope will be used if omitted

--- a/modules/policyDefAssignment/resourceGroup/outputs.tf
+++ b/modules/policyDefAssignment/resourceGroup/outputs.tf
@@ -18,6 +18,6 @@ output "remediation_id" {
 }
 
 output "role_definition_ids" {
-  description = "The List of Role Defenition Ids assignable to the managed identity"
+  description = "The List of Role Definition Ids assignable to the managed identity"
   value       = local.role_definition_ids
 }

--- a/modules/policyDefAssignment/subscription/locals.tf
+++ b/modules/policyDefAssignment/subscription/locals.tf
@@ -23,7 +23,7 @@ locals {
   # determine if a managed identity should be created with this assignment
   identity_type = length(try(coalescelist(var.role_definition_ids, lookup(jsondecode(var.definition.policy_rule).then.details, "roleDefinitionIds", [])), [])) > 0 ? var.identity_ids != null ? { type = "UserAssigned" } : { type = "SystemAssigned" } : {}
 
-  # try to use policy definition roles if explicit roles are ommitted
+  # try to use policy definition roles if explicit roles are omitted
   role_definition_ids = var.skip_role_assignment == false ? try(coalescelist(var.role_definition_ids, lookup(jsondecode(var.definition.policy_rule).then.details, "roleDefinitionIds", [])), []) : []
 
   # policy assignment scope will be used if omitted

--- a/modules/policyDefAssignment/subscription/outputs.tf
+++ b/modules/policyDefAssignment/subscription/outputs.tf
@@ -18,6 +18,6 @@ output "remediation_id" {
 }
 
 output "role_definition_ids" {
-  description = "The List of Role Defenition Ids assignable to the managed identity"
+  description = "The List of Role Definition Ids assignable to the managed identity"
   value       = local.role_definition_ids
 }

--- a/modules/policyExemption/managmentGroup/variables.tf
+++ b/modules/policyExemption/managmentGroup/variables.tf
@@ -28,13 +28,13 @@ variable "policy_assignment_id" {
 
 variable "policy_definition_reference_ids" {
   type        = list(string)
-  description = "The optional policy definition reference ID list when the associated policy assignment is an assignment of a policy set definition. Ommit to exempt all member definitions"
+  description = "The optional policy definition reference ID list when the associated policy assignment is an assignment of a policy set definition. Omit to exempt all member definitions"
   default     = []
 }
 
 variable "member_definition_names" {
   type        = list(string)
-  description = "Generate the definition reference Ids from the member definition names when 'policy_definition_reference_ids' are unknown. Ommit to exempt all member definitions"
+  description = "Generate the definition reference Ids from the member definition names when 'policy_definition_reference_ids' are unknown. Omit to exempt all member definitions"
   default     = []
 }
 

--- a/modules/policyExemption/resource/variables.tf
+++ b/modules/policyExemption/resource/variables.tf
@@ -28,13 +28,13 @@ variable "policy_assignment_id" {
 
 variable "policy_definition_reference_ids" {
   type        = list(string)
-  description = "The optional policy definition reference ID list when the associated policy assignment is an assignment of a policy set definition. Ommit to exempt all member definitions"
+  description = "The optional policy definition reference ID list when the associated policy assignment is an assignment of a policy set definition. Omit to exempt all member definitions"
   default     = []
 }
 
 variable "member_definition_names" {
   type        = list(string)
-  description = "Generate the definition reference Ids from the member definition names when 'policy_definition_reference_ids' are unknown. Ommit to exempt all member definitions"
+  description = "Generate the definition reference Ids from the member definition names when 'policy_definition_reference_ids' are unknown. Omit to exempt all member definitions"
   default     = []
 }
 

--- a/modules/policyExemption/resourceGroup/variables.tf
+++ b/modules/policyExemption/resourceGroup/variables.tf
@@ -28,13 +28,13 @@ variable "policy_assignment_id" {
 
 variable "policy_definition_reference_ids" {
   type        = list(string)
-  description = "The optional policy definition reference ID list when the associated policy assignment is an assignment of a policy set definition. Ommit to exempt all member definitions"
+  description = "The optional policy definition reference ID list when the associated policy assignment is an assignment of a policy set definition. Omit to exempt all member definitions"
   default     = []
 }
 
 variable "member_definition_names" {
   type        = list(string)
-  description = "Generate the definition reference Ids from the member definition names when 'policy_definition_reference_ids' are unknown. Ommit to exempt all member definitions"
+  description = "Generate the definition reference Ids from the member definition names when 'policy_definition_reference_ids' are unknown. Omit to exempt all member definitions"
   default     = []
 }
 

--- a/modules/policyExemption/subscription/variables.tf
+++ b/modules/policyExemption/subscription/variables.tf
@@ -28,13 +28,13 @@ variable "policy_assignment_id" {
 
 variable "policy_definition_reference_ids" {
   type        = list(string)
-  description = "The optional policy definition reference ID list when the associated policy assignment is an assignment of a policy set definition. Ommit to exempt all member definitions"
+  description = "The optional policy definition reference ID list when the associated policy assignment is an assignment of a policy set definition. Omit to exempt all member definitions"
   default     = []
 }
 
 variable "member_definition_names" {
   type        = list(string)
-  description = "Generate the definition reference Ids from the member definition names when 'policy_definition_reference_ids' are unknown. Ommit to exempt all member definitions"
+  description = "Generate the definition reference Ids from the member definition names when 'policy_definition_reference_ids' are unknown. Omit to exempt all member definitions"
   default     = []
 }
 

--- a/modules/policyInitiative/README.md
+++ b/modules/policyInitiative/README.md
@@ -30,7 +30,7 @@ No modules.
 | <a name="input_initiative_name"></a> [initiative\_name](#input\_initiative\_name) | Policy initiative name. Changing this forces a new resource to be created | `string` | n/a | yes |
 | <a name="input_initiative_version"></a> [initiative\_version](#input\_initiative\_version) | The version for this initiative, defaults to 1.0.0 | `string` | `"1.0.0"` | no |
 | <a name="input_management_group_id"></a> [management\_group\_id](#input\_management\_group\_id) | The management group scope at which the initiative will be defined. Defaults to current Subscription if omitted. Changing this forces a new resource to be created. Note: if you are using azurerm\_management\_group to assign a value to management\_group\_id, be sure to use name or group\_id attribute, but not id. | `string` | `null` | no |
-| <a name="input_member_definitions"></a> [member\_definitions](#input\_member\_definitions) | Policy Defenition resource nodes that will be members of this initiative | `any` | n/a | yes |
+| <a name="input_member_definitions"></a> [member\_definitions](#input\_member\_definitions) | Policy Definition resource nodes that will be members of this initiative | `any` | n/a | yes |
 | <a name="input_merge_effects"></a> [merge\_effects](#input\_merge\_effects) | Should the module merge all member definition effects? Defauls to true | `bool` | `true` | no |
 | <a name="input_merge_parameters"></a> [merge\_parameters](#input\_merge\_parameters) | Should the module merge all member definition parameters? Defauls to true | `bool` | `true` | no |
 

--- a/modules/policyInitiative/locals.tf
+++ b/modules/policyInitiative/locals.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 locals {
-  # colate all definition parameters into a single object
+  # collate all definition parameters into a single object
   member_parameters = {
     for d in var.member_definitions :
     d.name => try(jsondecode(d.parameters), {})

--- a/modules/policyInitiative/variables.tf
+++ b/modules/policyInitiative/variables.tf
@@ -52,7 +52,7 @@ variable "initiative_version" {
 
 variable "member_definitions" {
   type        = any
-  description = "Policy Defenition resource nodes that will be members of this initiative"
+  description = "Policy Definition resource nodes that will be members of this initiative"
 }
 
 variable "initiative_metadata" {

--- a/modules/policySetAssignment/managementGroup/locals.tf
+++ b/modules/policySetAssignment/managementGroup/locals.tf
@@ -26,7 +26,7 @@ locals {
   # determine if a managed identity should be created with this assignment
   identity_type = length(try(coalescelist(var.role_definition_ids, try(var.initiative.role_definition_ids, [])), [])) > 0 ? length(var.identity_ids) > 0 ? { type = "UserAssigned" } : { type = "SystemAssigned" } : {}
 
-  # try to use policy definition roles if explicit roles are ommitted
+  # try to use policy definition roles if explicit roles are omitted
   role_definition_ids = var.skip_role_assignment == false && try(values(local.identity_type)[0], "") == "SystemAssigned" ? try(coalescelist(var.role_definition_ids, try(var.initiative.role_definition_ids, [])), []) : []
 
   # assignment location is required when identity is specified

--- a/modules/policySetAssignment/resource/locals.tf
+++ b/modules/policySetAssignment/resource/locals.tf
@@ -26,7 +26,7 @@ locals {
   # determine if a managed identity should be created with this assignment
   identity_type = length(try(coalescelist(var.role_definition_ids, try(var.initiative.role_definition_ids, [])), [])) > 0 ? length(var.identity_ids) > 0 ? { type = "UserAssigned" } : { type = "SystemAssigned" } : {}
 
-  # try to use policy definition roles if explicit roles are ommitted
+  # try to use policy definition roles if explicit roles are omitted
   role_definition_ids = var.skip_role_assignment == false && try(values(local.identity_type)[0], "") == "SystemAssigned" ? try(coalescelist(var.role_definition_ids, try(var.initiative.role_definition_ids, [])), []) : []
 
   # assignment location is required when identity is specified

--- a/modules/policySetAssignment/resourceGroup/locals.tf
+++ b/modules/policySetAssignment/resourceGroup/locals.tf
@@ -26,7 +26,7 @@ locals {
   # determine if a managed identity should be created with this assignment
   identity_type = length(try(coalescelist(var.role_definition_ids, try(var.initiative.role_definition_ids, [])), [])) > 0 ? length(var.identity_ids) > 0 ? { type = "UserAssigned" } : { type = "SystemAssigned" } : {}
 
-  # try to use policy definition roles if explicit roles are ommitted
+  # try to use policy definition roles if explicit roles are omitted
   role_definition_ids = var.skip_role_assignment == false && try(values(local.identity_type)[0], "") == "SystemAssigned" ? try(coalescelist(var.role_definition_ids, try(var.initiative.role_definition_ids, [])), []) : []
 
   # assignment location is required when identity is specified

--- a/modules/policySetAssignment/subscription/locals.tf
+++ b/modules/policySetAssignment/subscription/locals.tf
@@ -26,7 +26,7 @@ locals {
   # determine if a managed identity should be created with this assignment
   identity_type = length(try(coalescelist(var.role_definition_ids, try(var.initiative.role_definition_ids, [])), [])) > 0 ? length(var.identity_ids) > 0 ? { type = "UserAssigned" } : { type = "SystemAssigned" } : {}
 
-  # try to use policy definition roles if explicit roles are ommitted
+  # try to use policy definition roles if explicit roles are omitted
   role_definition_ids = var.skip_role_assignment == false && try(values(local.identity_type)[0], "") == "SystemAssigned" ? try(coalescelist(var.role_definition_ids, try(var.initiative.role_definition_ids, [])), []) : []
 
   # assignment location is required when identity is specified


### PR DESCRIPTION
Correct spelling across repo.  Fixes issue #24